### PR TITLE
Fix eccentricity parsing for SXS waveforms

### DIFF
--- a/bayRing/NR_waveforms.py
+++ b/bayRing/NR_waveforms.py
@@ -1160,8 +1160,8 @@ class NR_simulation():
         ecc              = metadata['reference-eccentricity']
 
         if isinstance(ecc, str):    
-            ecc = 1e-4
-            
+            ecc = float(ecc[1:])
+
         return q, chi1, chi2, tilt1, tilt2, ecc, Mf, chif
 
     # FIXME: The two functions below have been written in a rush and should be adapted to the overall code style.


### PR DESCRIPTION
*Tested only for SXS waveforms, but issue might appear in other waveform models*

For certain waveforms, e.g., SXS:BBH:0178, the eccentricity was getting parsed as `ecc = '<1.8e-3'`, i.e., as a string. 

This was returning an error when calling `waveform_utils.find_peak_time`. 

Now it checks whether it is a string, and in that case, it removes the smaller sign (and chooses the maximum value, in the above example, 1.8e-3). 