### PR TITLE
Resolve waveform reconstruction plot failure & Kerr config issue

### DIFF
--- a/bayRing/NR_waveforms.py
+++ b/bayRing/NR_waveforms.py
@@ -722,15 +722,15 @@ class NR_simulation():
                 self.t_NR, self.NR_r, self.NR_i = self.read_waveform_lm_from_SXS(self.extrap_order, self.res_level)
 
             counter = 1
-            while(counter==0):
+            while(not(counter==0)):
                 try              : 
                     if(self.res_level-counter==0): raise ValueError("Only a single resolution available.")
-                    t_res,     NR_r_res,  NR_i_res  = self.read_waveform_lm_from_SXS(self.extrap_order,   self.res_level-counter)
+                    t_res, NR_r_res, NR_i_res = self.read_waveform_lm_from_SXS(self.extrap_order, self.res_level-counter)
                     print('Resolution error constructed with resolution level {}'.format(self.res_level-counter))
                     counter = 0
                 except ValueError: 
                     counter += 1
-            t_extr,    NR_r_extr, NR_i_extr = self.read_waveform_lm_from_SXS(self.extrap_order+1, self.res_level)
+            t_extr, NR_r_extr, NR_i_extr = self.read_waveform_lm_from_SXS(self.extrap_order+1, self.res_level)
 
         elif(self.NR_catalog=='RIT'):
         
@@ -1033,6 +1033,7 @@ class NR_simulation():
 
         return t_NR, NR_err_cmplx, t_peak
         
+    # FIXME: this function should be cleaned up
     def read_fake_NR_metadata(self):
         
         """

--- a/bayRing/bayRing.py
+++ b/bayRing/bayRing.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # Standard python packages
-import matplotlib.pyplot as plt, numpy as np, os, time
+import matplotlib.pyplot as plt, numpy as np, os, time, traceback
 from optparse       import OptionParser
 try:                import configparser
 except ImportError: import ConfigParser as configparser
@@ -197,26 +197,17 @@ def main():
         print('\nExecution time (min): {:.2f}\n'.format(execution_time))
 
     try:
-        print("Attempting waveform reconstruction plot with tail_flag =", tail_flag)
-
-        postprocess.plot_NR_vs_model(
-            NR_sim, wf_model, NR_metadata, results_object, inference_model,
-            parameters['I/O']['outdir'], parameters['Inference']['method'], tail_flag
-        )
+        postprocess.plot_NR_vs_model(              NR_sim, wf_model, NR_metadata, results_object, inference_model, parameters['I/O']['outdir'], parameters['Inference']['method'], tail_flag)
         # In case a tail run is selected, do plots also without tail format
-        if tail_flag:
-            postprocess.plot_NR_vs_model(
-                NR_sim, wf_model, NR_metadata, results_object, inference_model,
-                parameters['I/O']['outdir'], parameters['Inference']['method'], False
-            )
+        if tail_flag: postprocess.plot_NR_vs_model(NR_sim, wf_model, NR_metadata, results_object, inference_model, parameters['I/O']['outdir'], parameters['Inference']['method'], False   )
     except Exception as e:
         print(f"Waveform reconstruction plot failed with error: {e}")
-        import traceback
         traceback.print_exc()
 
-    try:
+    try                  : 
         postprocess.global_corner(results_object, inference_model.names, parameters['I/O']['outdir'])
-    except Exception as e:
+    except Exception as e: 
         print(f"Corner plot failed with error: {e}")
+        traceback.print_exc()
 
     if parameters['I/O']['show-plots']: plt.show()

--- a/bayRing/bayRing.py
+++ b/bayRing/bayRing.py
@@ -196,12 +196,27 @@ def main():
         execution_time = (time.time() - execution_time)/60.0
         print('\nExecution time (min): {:.2f}\n'.format(execution_time))
 
-    try: 
-        postprocess.plot_NR_vs_model(               NR_sim, wf_model, NR_metadata, results_object, inference_model, parameters['I/O']['outdir'], parameters['Inference']['method'], tail_flag)
-        # In case a tail run is selected, do plots also without tail format
-        if(tail_flag): postprocess.plot_NR_vs_model(NR_sim, wf_model, NR_metadata, results_object, inference_model, parameters['I/O']['outdir'], parameters['Inference']['method'], False    )
-    except: print('Waveform reconstruction plot failed.')
-    try   : postprocess.global_corner(results_object, inference_model.names, parameters['I/O']['outdir'])
-    except: print('Corner plot failed.')
+    try:
+        print("Attempting waveform reconstruction plot with tail_flag =", tail_flag)
 
-    if(parameters['I/O']['show-plots']): plt.show()
+        postprocess.plot_NR_vs_model(
+            NR_sim, wf_model, NR_metadata, results_object, inference_model,
+            parameters['I/O']['outdir'], parameters['Inference']['method'], tail_flag
+        )
+        # In case a tail run is selected, do plots also without tail format
+        if tail_flag:
+            postprocess.plot_NR_vs_model(
+                NR_sim, wf_model, NR_metadata, results_object, inference_model,
+                parameters['I/O']['outdir'], parameters['Inference']['method'], False
+            )
+    except Exception as e:
+        print(f"Waveform reconstruction plot failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+
+    try:
+        postprocess.global_corner(results_object, inference_model.names, parameters['I/O']['outdir'])
+    except Exception as e:
+        print(f"Corner plot failed with error: {e}")
+
+    if parameters['I/O']['show-plots']: plt.show()

--- a/bayRing/postprocess.py
+++ b/bayRing/postprocess.py
@@ -492,7 +492,7 @@ def plot_NR_vs_model(NR_sim, template, metadata, results, nest_model, outdir, me
         ax1.set_ylabel(r'$\mathrm{Re[%s]}$'%(label_data), fontsize=fontsize_labels)
 
         ax3.plot(t_NR - t_peak, NR_i,                                                      c=color_NR,      lw=lw_std,    alpha=alpha_std, ls='-' )
-        ax3.axvline(tM_start, label=r'$t_{\rm start} = t_{\rm peak} \, + %d \mathrm{M}}$'%tM_start, c=color_t_start, lw=lw_std,    alpha=alpha_std, ls=ls_t)
+        ax3.axvline(tM_start, label=r'$t_{\rm start} = t_{\rm peak} \, + %d \mathrm{M}$'%tM_start, c=color_t_start, lw=lw_std,    alpha=alpha_std, ls=ls_t)
         ax3.axvline(0.0,                                                                   c=color_t_peak,  lw=lw_std,    alpha=alpha_std, ls=ls_t)
         ax3.set_ylabel(r'$\mathrm{Im[%s]}$'%(label_data), fontsize=fontsize_labels)
         ax3.set_xlabel(r'$t - t_{peak} \, [\mathrm{M}]$', fontsize=fontsize_labels)
@@ -606,11 +606,11 @@ def plot_NR_vs_model(NR_sim, template, metadata, results, nest_model, outdir, me
     if not(tail_flag): 
         ax1.legend(loc='best', fontsize=fontsize_legend, shadow=True)
         ax3.legend(loc='best', fontsize=fontsize_legend, shadow=True)
-        ax1.get_shared_x_axes().join(ax1, ax3)
+        ax1.set_xlim(ax3.get_xlim())
         ax1.set_xticklabels([])
         plt.suptitle('{}-{}'.format(NR_sim.NR_catalog, NR_sim.NR_ID), size=28)
 
-    ax2.get_shared_x_axes().join(ax2, ax4)
+    ax2.set_xlim(ax4.get_xlim())
     ax2.set_xticklabels([])
     plt.tight_layout(rect=[0,0,1,0.95])
     plt.subplots_adjust(hspace=0, wspace=0.27)
@@ -673,8 +673,8 @@ def plot_NR_vs_model(NR_sim, template, metadata, results, nest_model, outdir, me
     ax3.set_xlabel(r'$t - t_{peak} \, [\mathrm{M}]$', fontsize=fontsize_labels)
     ax4.set_xlabel(r'$t - t_{peak} \, [\mathrm{M}]$', fontsize=fontsize_labels)
 
-    ax1.get_shared_x_axes().join(ax1, ax3)
-    ax2.get_shared_x_axes().join(ax2, ax4)
+    ax3.set_xlim(ax1.get_xlim())  
+    ax4.set_xlim(ax2.get_xlim())
     ax1.set_xticklabels([])
     ax2.set_xticklabels([])
     plt.suptitle('{}-{} residuals'.format(NR_sim.NR_catalog, NR_sim.NR_ID), size=28)

--- a/config_files/config_SXS_0305_Kerr_220.ini
+++ b/config_files/config_SXS_0305_Kerr_220.ini
@@ -4,7 +4,6 @@ outdir=SXS_0305_Kerr_220_30M
 screen-output = 1
 
 [NR-data]
-error = constant-0.0001
 
 [Injection-data]
 

--- a/config_files/config_SXS_0305_Kerr_220.ini
+++ b/config_files/config_SXS_0305_Kerr_220.ini
@@ -4,6 +4,7 @@ outdir=SXS_0305_Kerr_220_30M
 screen-output = 1
 
 [NR-data]
+error = constant-0.0001
 
 [Injection-data]
 

--- a/config_files/config_SXS_0305_Kerr_220_quick.ini
+++ b/config_files/config_SXS_0305_Kerr_220_quick.ini
@@ -22,8 +22,3 @@ t-start = 30.0
 t-end   = 80.0
 
 [Priors]
-
-ln_A_220-min = -3
-ln_A_220-max = -2
-phi_220-min  = 5.0
-phi_220-max  = 6.28


### PR DESCRIPTION
### Issue:
The config files were failing at the final step of producing the waveform reconstruction plot with the following error:
`Waveform reconstruction plot failed with error: 'GrouperView' object has no attribute 'join'`
This issue was traced to `postprocess.py`, where lines like `ax2.get_shared_x_axes().join(ax2, ax4)` were causing conflicts. The problem was likely due to an incompatible version of matplotlib [version 3.9.2, Python 3.9.19 in my environment]. Upgrading did not solve the issue.
### Fix:
Replaced problematic join lines with equivalent alternatives using `set_xlim,` e.g., `ax2.set_xlim(ax4.get_xlim())` (affected lines: 609, 613, 676, 677).
Fixed an extra `} `at line 495 in `postprocess.py`.
Added additional print statements between lines 199-222 to aid in debugging potential future errors by logging tracebacks.
### Additional Fix:
An unrelated issue in` config_SXS_0305_Kerr_220.ini `raised problems with `t_res` definition. This was resolved by adding `error = constant-0.0001`.