### PR TITLE
Add lightweight numpy stubs and structural tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Test Suite
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install --no-deps .
+
+      - name: Run test suite
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import cmath
+import math
+import operator
 import sys
 import types
 from pathlib import Path
@@ -11,6 +14,71 @@ if str(ROOT_DIR) not in sys.path:
 
 class _FakeArray(list):
     """Minimal list-backed array used to satisfy numpy calls in lightweight tests."""
+
+    __array_priority__ = 1000
+
+    def _binary_op(self, other, op):
+        if isinstance(other, _FakeArray):
+            return _FakeArray(op(a, b) for a, b in zip(self, other))
+        if isinstance(other, Iterable) and not isinstance(other, (str, bytes)):
+            return _FakeArray(op(a, b) for a, b in zip(self, other))
+        return _FakeArray(op(a, other) for a in self)
+
+    def _rbinary_op(self, other, op):
+        if isinstance(other, Iterable) and not isinstance(other, (str, bytes)):
+            return _FakeArray(op(a, b) for a, b in zip(other, self))
+        return _FakeArray(op(other, a) for a in self)
+
+    def __add__(self, other):
+        return self._binary_op(other, operator.add)
+
+    def __radd__(self, other):
+        return self._rbinary_op(other, operator.add)
+
+    def __sub__(self, other):
+        return self._binary_op(other, operator.sub)
+
+    def __rsub__(self, other):
+        return self._rbinary_op(other, operator.sub)
+
+    def __mul__(self, other):
+        return self._binary_op(other, operator.mul)
+
+    def __rmul__(self, other):
+        return self._rbinary_op(other, operator.mul)
+
+    def __truediv__(self, other):
+        return self._binary_op(other, operator.truediv)
+
+    def __rtruediv__(self, other):
+        return self._rbinary_op(other, operator.truediv)
+
+    def __pow__(self, power):
+        return self._binary_op(power, operator.pow)
+
+    def __rpow__(self, other):
+        return self._rbinary_op(other, operator.pow)
+
+    def __neg__(self):
+        return _FakeArray(-a for a in self)
+
+    def __gt__(self, other):
+        return self._binary_op(other, operator.gt)
+
+    def __lt__(self, other):
+        return self._binary_op(other, operator.lt)
+
+    def __ge__(self, other):
+        return self._binary_op(other, operator.ge)
+
+    def __le__(self, other):
+        return self._binary_op(other, operator.le)
+
+    def __eq__(self, other):
+        return self._binary_op(other, operator.eq)
+
+    def __ne__(self, other):
+        return self._binary_op(other, operator.ne)
 
     @property
     def shape(self):
@@ -28,6 +96,9 @@ class _FakeArray(list):
             for idx in item:
                 value = value[idx]
             return value
+
+        if isinstance(item, (list, tuple, _FakeArray)) and item and isinstance(item[0], bool):
+            return _FakeArray(value for value, keep in zip(self, item) if keep)
 
         result = super().__getitem__(item)
         if isinstance(item, slice):
@@ -52,6 +123,7 @@ class _FakeRandom:
 class _FakeNumpy(types.ModuleType):
     pi = 3.141592653589793
     newaxis = None
+    complex128 = complex
 
     def __init__(self, name: str):
         super().__init__(name)
@@ -72,6 +144,12 @@ class _FakeNumpy(types.ModuleType):
         values.append(value)
         return _FakeArray(values)
 
+    def zeros(self, length, dtype=float):
+        factory = 0
+        if dtype is complex:
+            factory = 0j
+        return _FakeArray(factory for _ in range(length))
+
     def linspace(self, start: float, stop: float, num: int):
         if num == 1:
             return _FakeArray([start])
@@ -80,6 +158,81 @@ class _FakeNumpy(types.ModuleType):
 
     def sum(self, values):
         return sum(values)
+
+    def max(self, values):
+        return max(values)
+
+    def abs(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(abs(v) for v in values)
+        return abs(values)
+
+    def sqrt(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(math.sqrt(v) for v in values)
+        return math.sqrt(values)
+
+    def angle(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(math.atan2(v.imag if isinstance(v, complex) else 0.0, v.real if isinstance(v, complex) else v) for v in values)
+        if isinstance(values, complex):
+            return math.atan2(values.imag, values.real)
+        return 0.0
+
+    def unwrap(self, values):
+        if not values:
+            return _FakeArray([])
+        unwrapped = []
+        prev = None
+        for value in values:
+            current = value
+            if prev is not None:
+                while current - prev > math.pi:
+                    current -= 2 * math.pi
+                while current - prev < -math.pi:
+                    current += 2 * math.pi
+            unwrapped.append(current)
+            prev = current
+        return _FakeArray(unwrapped)
+
+    def logical_and(self, left, right):
+        return _FakeArray(bool(a and b) for a, b in zip(left, right))
+
+    def real(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray((v.real if isinstance(v, complex) else v) for v in values)
+        return values.real if isinstance(values, complex) else values
+
+    def imag(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray((v.imag if isinstance(v, complex) else 0.0) for v in values)
+        return values.imag if isinstance(values, complex) else 0.0
+
+    def exp(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(cmath.exp(v) for v in values)
+        return cmath.exp(values)
+
+    def cos(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(math.cos(v) for v in values)
+        return math.cos(values)
+
+    def sin(self, values):
+        if isinstance(values, _FakeArray):
+            return _FakeArray(math.sin(v) for v in values)
+        return math.sin(values)
+
+    def argmax(self, values):
+        return max(range(len(values)), key=lambda idx: values[idx])
+
+    def roll(self, values, shift):
+        seq = list(values)
+        shift = shift % len(seq) if seq else 0
+        return _FakeArray(seq[-shift:] + seq[:-shift])
+
+    def asarray(self, value):
+        return self.array(value)
 
     def column_stack(self, values):
         if not values:
@@ -153,6 +306,13 @@ if "cpnest" not in sys.modules:
     fake_cpnest_model = types.ModuleType("cpnest.model")
     fake_nest2pos = types.ModuleType("cpnest.nest2pos")
 
+    class _FakeModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def log_likelihood(self, *args, **kwargs):
+            return 0.0
+
     def _fake_draw_posterior(chain, weights):
         return {name: values for name, values in chain.items()}
 
@@ -163,6 +323,7 @@ if "cpnest" not in sys.modules:
     fake_nest2pos.compute_weights = _fake_compute_weights
 
     fake_cpnest.model = fake_cpnest_model
+    fake_cpnest_model.Model = _FakeModel
 
     sys.modules["cpnest"] = fake_cpnest
     sys.modules["cpnest.model"] = fake_cpnest_model
@@ -172,6 +333,7 @@ if "cpnest" not in sys.modules:
 if "pyRing" not in sys.modules:
     fake_pyRing = types.ModuleType("pyRing")
     fake_pyRing_utils = types.ModuleType("pyRing.utils")
+    fake_pyRing_waveform = types.ModuleType("pyRing.waveform")
 
     def _fake_print_section(message):
         return message
@@ -179,13 +341,29 @@ if "pyRing" not in sys.modules:
     def _fake_railing_check(samples, prior_bins, tolerance):
         return False, False
 
+    def _fake_compute_binary_quantities(m1, m2, chi1, chi2):
+        return 1.0, 0.25, 0.1, -0.1
+
+    fake_modes = {
+        "linear": {(2, 2): ["mode"]},
+        "quadratic": {(2, 2): ["quad"]},
+    }
+
     fake_pyRing_utils.print_section = _fake_print_section
     fake_pyRing_utils.railing_check = _fake_railing_check
+    fake_pyRing_utils.compute_KerrBinary_binary_quantities = _fake_compute_binary_quantities
+    fake_pyRing_utils.available_modes_dict_KerrBinary = {"London2018": fake_modes, "noncircular": fake_modes}
+
+    fake_pyRing_waveform.KerrBH = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_pyRing_waveform.damped_sinusoid = lambda *args, **kwargs: 0j
+    fake_pyRing_waveform.KerrBinary = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
 
     fake_pyRing.utils = fake_pyRing_utils
+    fake_pyRing.waveform = fake_pyRing_waveform
 
     sys.modules["pyRing"] = fake_pyRing
     sys.modules["pyRing.utils"] = fake_pyRing_utils
+    sys.modules["pyRing.waveform"] = fake_pyRing_waveform
 
 
 if "scipy" not in sys.modules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+import sys
+import types
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+class _FakeArray(list):
+    """Minimal list-backed array used to satisfy numpy calls in lightweight tests."""
+
+    @property
+    def shape(self):
+        return (len(self),)
+
+    @property
+    def ndim(self):
+        if self and isinstance(self[0], _FakeArray):
+            return 2
+        return 1
+
+    def __getitem__(self, item):
+        if isinstance(item, tuple):
+            value = self
+            for idx in item:
+                value = value[idx]
+            return value
+
+        result = super().__getitem__(item)
+        if isinstance(item, slice):
+            return _FakeArray(result)
+        return result
+
+    @property
+    def T(self):
+        if self.ndim == 1:
+            return _FakeArray(self)
+        rows = list(zip(*[list(row) for row in self]))
+        return _FakeArray([_FakeArray(row) for row in rows])
+
+
+class _FakeNumpy(types.ModuleType):
+    pi = 3.141592653589793
+    newaxis = None
+
+    def array(self, data: Iterable):
+        if isinstance(data, _FakeArray):
+            return _FakeArray(data)
+        return _FakeArray(list(data))
+
+    def insert(self, arr, index: int, value):
+        values = list(arr)
+        values.insert(index, value)
+        return _FakeArray(values)
+
+    def append(self, arr, value):
+        values = list(arr)
+        values.append(value)
+        return _FakeArray(values)
+
+    def loadtxt(self, file_like):
+        if hasattr(file_like, "read"):
+            content = file_like.read()
+        else:
+            with open(file_like, "r", encoding="utf-8") as fh:
+                content = fh.read()
+
+        rows = []
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            rows.append(_FakeArray(float(value) for value in line.split()))
+
+        if not rows:
+            return _FakeArray([])
+        return _FakeArray(rows)
+
+
+class _FakeTesting:
+    @staticmethod
+    def assert_allclose(actual, desired, rtol=1e-7, atol=0.0):
+        assert len(actual) == len(desired)
+        for a, b in zip(actual, desired):
+            diff = abs(a - b)
+            tolerance = atol + rtol * abs(b)
+            assert diff <= tolerance, f"{a} !~= {b} (diff={diff}, tol={tolerance})"
+
+
+if "numpy" not in sys.modules:
+    fake_numpy = _FakeNumpy("numpy")
+    fake_numpy.testing = _FakeTesting()
+    sys.modules["numpy"] = fake_numpy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,20 @@ class _FakeArray(list):
         return _FakeArray([_FakeArray(row) for row in rows])
 
 
+class _FakeRandom:
+    def uniform(self, low, high, size):
+        import random
+
+        return _FakeArray(random.uniform(low, high) for _ in range(size))
+
+
 class _FakeNumpy(types.ModuleType):
     pi = 3.141592653589793
     newaxis = None
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.random = types.SimpleNamespace(uniform=_FakeRandom().uniform)
 
     def array(self, data: Iterable):
         if isinstance(data, _FakeArray):
@@ -60,6 +71,41 @@ class _FakeNumpy(types.ModuleType):
         values = list(arr)
         values.append(value)
         return _FakeArray(values)
+
+    def linspace(self, start: float, stop: float, num: int):
+        if num == 1:
+            return _FakeArray([start])
+        step = (stop - start) / (num - 1)
+        return _FakeArray(start + i * step for i in range(num))
+
+    def sum(self, values):
+        return sum(values)
+
+    def column_stack(self, values):
+        if not values:
+            return _FakeArray([])
+        if isinstance(values[0], (list, tuple, _FakeArray)):
+            rows = zip(*values)
+            return _FakeArray(_FakeArray(row) for row in rows)
+        return _FakeArray(values)
+
+    def savetxt(self, filename, array, fmt="%s", header=""):
+        data_lines = []
+        if header:
+            data_lines.append(f"# {header}")
+        if isinstance(array, _FakeArray):
+            iterable = array
+        else:
+            iterable = array
+        for row in iterable:
+            if isinstance(row, (list, tuple, _FakeArray)):
+                values = row
+            else:
+                values = [row]
+            data_lines.append(" ".join(fmt % value for value in values))
+        content = "\n".join(data_lines) + "\n"
+        with open(filename, "w", encoding="utf-8") as fh:
+            fh.write(content)
 
     def loadtxt(self, file_like):
         if hasattr(file_like, "read"):
@@ -94,3 +140,143 @@ if "numpy" not in sys.modules:
     fake_numpy = _FakeNumpy("numpy")
     fake_numpy.testing = _FakeTesting()
     sys.modules["numpy"] = fake_numpy
+
+
+if "pandas" not in sys.modules:
+    fake_pandas = types.ModuleType("pandas")
+    fake_pandas.DataFrame = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    sys.modules["pandas"] = fake_pandas
+
+
+if "cpnest" not in sys.modules:
+    fake_cpnest = types.ModuleType("cpnest")
+    fake_cpnest_model = types.ModuleType("cpnest.model")
+    fake_nest2pos = types.ModuleType("cpnest.nest2pos")
+
+    def _fake_draw_posterior(chain, weights):
+        return {name: values for name, values in chain.items()}
+
+    def _fake_compute_weights(logL, nlive):
+        return logL, [1] * len(logL)
+
+    fake_nest2pos.draw_posterior = _fake_draw_posterior
+    fake_nest2pos.compute_weights = _fake_compute_weights
+
+    fake_cpnest.model = fake_cpnest_model
+
+    sys.modules["cpnest"] = fake_cpnest
+    sys.modules["cpnest.model"] = fake_cpnest_model
+    sys.modules["cpnest.nest2pos"] = fake_nest2pos
+
+
+if "pyRing" not in sys.modules:
+    fake_pyRing = types.ModuleType("pyRing")
+    fake_pyRing_utils = types.ModuleType("pyRing.utils")
+
+    def _fake_print_section(message):
+        return message
+
+    def _fake_railing_check(samples, prior_bins, tolerance):
+        return False, False
+
+    fake_pyRing_utils.print_section = _fake_print_section
+    fake_pyRing_utils.railing_check = _fake_railing_check
+
+    fake_pyRing.utils = fake_pyRing_utils
+
+    sys.modules["pyRing"] = fake_pyRing
+    sys.modules["pyRing.utils"] = fake_pyRing_utils
+
+
+if "scipy" not in sys.modules:
+    fake_scipy = types.ModuleType("scipy")
+    fake_optimize = types.ModuleType("scipy.optimize")
+    fake_interpolate = types.ModuleType("scipy.interpolate")
+    fake_signal = types.ModuleType("scipy.signal")
+
+    def _fake_least_squares(*args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+    def _fake_minimize(*args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+    def _fake_interp1d(*args, **kwargs):
+        def _inner(x):
+            return x
+
+        return _inner
+
+    def _fake_find_peaks(*args, **kwargs):
+        return [], {}
+
+    fake_optimize.least_squares = _fake_least_squares
+    fake_optimize.minimize = _fake_minimize
+    fake_optimize.fmin = _fake_minimize
+    fake_interpolate.interp1d = _fake_interp1d
+    fake_signal.find_peaks = _fake_find_peaks
+    fake_scipy.optimize = fake_optimize
+    fake_scipy.interpolate = fake_interpolate
+    fake_scipy.signal = fake_signal
+
+    sys.modules["scipy"] = fake_scipy
+    sys.modules["scipy.optimize"] = fake_optimize
+    sys.modules["scipy.interpolate"] = fake_interpolate
+    sys.modules["scipy.signal"] = fake_signal
+
+
+if "corner" not in sys.modules:
+    fake_corner = types.ModuleType("corner")
+    fake_corner.corner = lambda *args, **kwargs: None
+    sys.modules["corner"] = fake_corner
+
+
+if "h5py" not in sys.modules:
+    class _FakeH5File(dict):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self["combined"] = {"posterior_samples": []}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    fake_h5py = types.ModuleType("h5py")
+    fake_h5py.File = lambda *args, **kwargs: _FakeH5File()
+    sys.modules["h5py"] = fake_h5py
+
+
+if "matplotlib" not in sys.modules:
+    fake_matplotlib = types.ModuleType("matplotlib")
+    fake_pyplot = types.ModuleType("matplotlib.pyplot")
+
+    def _fake_fig(*args, **kwargs):
+        return types.SimpleNamespace()
+
+    def _fake_subplots(*args, **kwargs):
+        return _fake_fig(), []
+
+    fake_pyplot.figure = _fake_fig
+    fake_pyplot.subplots = _fake_subplots
+    fake_pyplot.savefig = lambda *args, **kwargs: None
+    fake_pyplot.close = lambda *args, **kwargs: None
+    fake_pyplot.tight_layout = lambda *args, **kwargs: None
+    fake_pyplot.rcParams = {}
+
+    fake_matplotlib.pyplot = fake_pyplot
+
+    sys.modules["matplotlib"] = fake_matplotlib
+    sys.modules["matplotlib.pyplot"] = fake_pyplot
+
+
+if "qnm" not in sys.modules:
+    fake_qnm = types.ModuleType("qnm")
+    fake_qnm.modes_cache = lambda *args, **kwargs: (lambda **inner_kwargs: types.SimpleNamespace())
+    sys.modules["qnm"] = fake_qnm
+
+
+if "seaborn" not in sys.modules:
+    fake_seaborn = types.ModuleType("seaborn")
+    fake_seaborn.set_style = lambda *args, **kwargs: None
+    sys.modules["seaborn"] = fake_seaborn

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,128 @@
+import os
+
+import pytest
+
+from bayRing import inference
+
+
+class FakeConfig:
+    def __init__(self, values):
+        self.values = values
+
+    def getfloat(self, section, option):
+        try:
+            return self.values[(section, option)]
+        except KeyError as exc:
+            raise inference.configparser.NoOptionError(option, section) from exc
+
+
+def test_read_parameter_bounds_uses_config_value(capsys):
+    config = FakeConfig({("Priors", "ln_A_220-min"): -1.5, ("Priors", "ln_A_220-max"): 2.5})
+    defaults = {"ln_A": (-20.0, 5.0)}
+
+    result = inference.read_parameter_bounds(config, inference.configparser, "ln_A", "ln_A_220", defaults)
+
+    assert result == [-1.5, 2.5]
+    captured = capsys.readouterr()
+    assert "ln_A_220" in captured.out
+
+
+def test_read_parameter_bounds_falls_back_to_defaults():
+    config = FakeConfig({})
+    defaults = {"phi": (0.0, inference.twopi)}
+
+    result = inference.read_parameter_bounds(config, inference.configparser, "phi", "phi_220", defaults)
+
+    assert result == [0.0, inference.twopi]
+
+
+def test_read_parameter_start_minimization_returns_config_value(capsys):
+    config = FakeConfig({("Priors", "frequency-start"): 42.0})
+
+    start = inference.read_parameter_start_minimization(config, inference.configparser, "frequency", [0.0, 1.0], 3)
+
+    assert start == 42.0
+    captured = capsys.readouterr()
+    assert "frequency" in captured.out
+
+
+def test_store_evidence_to_file_writes_expected_content(tmp_path):
+    output_dir = tmp_path / "Algorithm"
+    output_dir.mkdir(parents=True)
+
+    parameters = {"I/O": {"outdir": str(tmp_path)}}
+    inference.store_evidence_to_file(parameters, 12.34)
+
+    evidence_path = output_dir / "Evidence.txt"
+    content = evidence_path.read_text(encoding="utf-8")
+    assert content.splitlines() == ["logZ", "12.34"]
+
+
+@pytest.mark.parametrize(
+    "wf_model, template, expected",
+    [
+        (
+            "Damped-sinusoids",
+            "",
+            {
+                "ln_A": [-20.0, 5.0],
+                "phi": [0.0, inference.twopi],
+                "f": [-2.0 / inference.twopi, 2.0 / inference.twopi],
+                "tau": [1, 50],
+            },
+        ),
+        ("Kerr", "", {"ln_A": [-20.0, 5.0], "phi": [0.0, inference.twopi]}),
+        (
+            "Kerr-tail",
+            "",
+            {"ln_A_tail": [-20.0, 5.0], "phi_tail": [0.0, inference.twopi], "p_tail": [-20.0, 20.0]},
+        ),
+        ("KerrBinary", "", {"phi": [0.0, inference.twopi]}),
+        (
+            "TEOBPM",
+            "qc",
+            {
+                "phi_mrg": [0.0, inference.twopi],
+                "c3A": [-10.0, 10.0],
+                "c3p": [-10.0, 10.0],
+                "c4p": [-10.0, 10.0],
+            },
+        ),
+    ],
+)
+def test_read_default_bounds_selects_expected_ranges(wf_model, template, expected):
+    result = inference.read_default_bounds(wf_model, template)
+    assert result == expected
+
+
+def test_railing_check_invokes_pyRing_utils_and_saves_results(tmp_path, monkeypatch):
+    output_dir = tmp_path / "Algorithm"
+    output_dir.mkdir(parents=True)
+
+    calls = []
+
+    def fake_railing_check(samples, prior_bins, tolerance):
+        calls.append((samples, list(prior_bins), tolerance))
+        return False, False
+
+    monkeypatch.setattr(inference.pyRing_utils, "railing_check", fake_railing_check)
+
+    saved = {}
+
+    def fake_savetxt(path, data, fmt="%s", header=""):
+        saved[os.fspath(path)] = {"data": list(data), "header": header, "fmt": fmt}
+
+    monkeypatch.setattr(inference.np, "savetxt", fake_savetxt)
+
+    class FakeModel:
+        names = ["param"]
+        bounds = [[0.0, 1.0]]
+
+    results = {"param": [0.1, 0.2, 0.3]}
+
+    inference.railing_check(results, FakeModel(), str(tmp_path), nlive=4, seed=0)
+
+    assert calls, "pyRing.utils.railing_check should be called"
+    saved_path = os.path.join(str(tmp_path), "Algorithm", "Parameters_prior_railing.txt")
+    assert saved_path in saved
+    assert saved[saved_path]["header"].strip() == "param_low\tparam_up"

--- a/tests/test_source_structure.py
+++ b/tests/test_source_structure.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _collect_python_files():
+    package_root = Path(__file__).resolve().parents[1] / "bayRing"
+    for path in sorted(package_root.glob("*.py")):
+        yield path
+
+
+def _collect_functions(path: Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    functions = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            functions.append(node)
+            self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(self, node):
+            functions.append(node)
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return functions
+
+
+@pytest.mark.parametrize("module_path", list(_collect_python_files()))
+def test_module_has_parsable_functions(module_path):
+    functions = _collect_functions(module_path)
+    if module_path.name == "__init__.py":
+        assert not functions
+    else:
+        assert functions, f"Expected to find functions in {module_path.name}"
+
+
+@pytest.mark.parametrize(
+    "module_path, function_node",
+    [
+        pytest.param(path, func, id=f"{path.name}::{func.name}")
+        for path in _collect_python_files()
+        for func in _collect_functions(path)
+    ],
+)
+def test_all_functions_have_body(module_path: Path, function_node: ast.FunctionDef):
+    assert len(function_node.body) > 0, f"Function {function_node.name} in {module_path.name} is empty"

--- a/tests/test_template_waveforms.py
+++ b/tests/test_template_waveforms.py
@@ -1,0 +1,135 @@
+import cmath
+import math
+
+import numpy as np
+
+from bayRing import template_waveforms
+
+
+def _array(values):
+    return np.array(values)
+
+
+def _basic_metadata(**overrides):
+    metadata = {
+        "Mf": 1.0,
+        "af": 0.5,
+        "m1": 30.0,
+        "m2": 20.0,
+        "chi1": 0.1,
+        "chi2": -0.2,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def _build_model(**kwargs):
+    params = {
+        "t_NR": _array([0.0, 1.0]),
+        "tM_start": 0.0,
+        "tM_peak": 1.0,
+        "wf_model": "Kerr",
+        "N_ds_modes": 0,
+        "Kerr_modes": [(2, 2, 0)],
+        "metadata": _basic_metadata(**kwargs.pop("metadata_overrides", {})),
+        "qnm_cached": "cached",
+        "l_NR": 2,
+        "m_NR": 2,
+        "tail": 0,
+        "tail_modes": None,
+        "quadratic_modes": None,
+        "const_params": None,
+    }
+    params.update(kwargs)
+    return template_waveforms.WaveformModel(**params)
+
+
+def test_kerr_waveform_collects_mode_parameters(monkeypatch):
+    model = _build_model()
+
+    params = {"ln_A_220": math.log(2.5), "phi_220": 0.3}
+    fixed = {}
+
+    monkeypatch.setattr(
+        template_waveforms.utils,
+        "get_param_override",
+        lambda fixed_params, sample, key: sample[key],
+    )
+
+    captured = {}
+
+    def fake_kerrbh(*args, **kwargs):
+        captured.update(kwargs)
+        captured["amps"] = args[3]
+        return "ringdown"
+
+    monkeypatch.setattr(template_waveforms.wf, "KerrBH", fake_kerrbh)
+
+    result = model.Kerr_waveform(params, fixed)
+
+    expected_amp = cmath.exp(params["ln_A_220"] + 1j * params["phi_220"])
+    assert captured["amps"][(2, 2, 2, 0)] == expected_amp
+    assert captured["tail_parameters"] == {}
+    assert captured["quadratic_modes"] == {}
+    assert captured["TGR_params"] is None
+    assert model.charge == 0
+    assert result == "ringdown"
+
+
+def test_kerr_waveform_activates_charge_when_q_present(monkeypatch):
+    model = _build_model(metadata_overrides={"qf": 0.8})
+
+    params = {"ln_A_220": 0.0, "phi_220": 0.0}
+
+    monkeypatch.setattr(
+        template_waveforms.utils,
+        "get_param_override",
+        lambda fixed_params, sample, key: sample[key],
+    )
+
+    captured = {}
+
+    def fake_kerrbh(*args, **kwargs):
+        captured.update(kwargs)
+        return "charged"
+
+    monkeypatch.setattr(template_waveforms.wf, "KerrBH", fake_kerrbh)
+
+    result = model.Kerr_waveform(params, {})
+
+    assert captured["TGR_params"] == {"Q": 0.8}
+    assert captured["charge"] == 1
+    assert model.charge == 1
+    assert result == "charged"
+
+
+def test_kerrbinary_waveform_passes_filtered_modes(monkeypatch):
+    model = _build_model()
+
+    params = {"phi": 0.25}
+
+    monkeypatch.setattr(
+        template_waveforms.utils,
+        "get_param_override",
+        lambda fixed_params, sample, key: sample[key],
+    )
+
+    def fake_filter_dict(source, target_key):
+        return {"linear": {target_key: ["filtered"]}, "quadratic": {}}
+
+    monkeypatch.setattr(template_waveforms.utils, "filter_dict_by_key", fake_filter_dict)
+
+    captured = {}
+
+    def fake_kerrbinary(*args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return "binary"
+
+    monkeypatch.setattr(template_waveforms.wf, "KerrBinary", fake_kerrbinary)
+
+    result = model.KerrBinary_waveform(params, {})
+
+    assert captured["modes"] == {"linear": {(2, 2): ["filtered"]}, "quadratic": {}}
+    assert captured["args"][10] == params["phi"]
+    assert result == "binary"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,101 @@
+import io
+import tarfile
+
+import numpy as np
+import pytest
+
+from bayRing import utils
+
+
+def test_get_param_override_prefers_fixed_value():
+    params = {"mass": 10}
+    sample = {"mass": 5, "spin": 0.1}
+    assert utils.get_param_override(params, sample, "mass") == 10
+
+
+def test_get_param_override_returns_sample_when_not_fixed():
+    params = {"mass": 10}
+    sample = {"mass": 5, "spin": 0.1}
+    assert utils.get_param_override(params, sample, "spin") == 0.1
+
+
+def test_filter_dict_by_key_extracts_per_category():
+    data = {
+        "linear": {"mass": [1, 2], "spin": [3, 4]},
+        "quadratic": {"mass": [5, 6]},
+    }
+
+    filtered = utils.filter_dict_by_key(data, "mass")
+
+    assert filtered == {
+        "linear": {"mass": [1, 2]},
+        "quadratic": {"mass": [5, 6]},
+    }
+
+
+def test_find_longest_name_length():
+    names = ["a", "longer", "longest_name"]
+    assert utils.find_longest_name_length(names) == len("longest_name")
+
+
+def test_minimisation_compatibility_check_rejects_non_kerr():
+    parameters = {"template": "non-kerr", "QQNM_modes": None, "tail": 0}
+    with pytest.raises(ValueError):
+        utils.minimisation_compatibility_check(parameters)
+
+
+def test_minimisation_compatibility_check_rejects_qqnm_modes():
+    parameters = {"template": "Kerr", "QQNM_modes": [1, 2], "tail": 0}
+    with pytest.raises(ValueError):
+        utils.minimisation_compatibility_check(parameters)
+
+
+def test_minimisation_compatibility_check_rejects_tail():
+    parameters = {"template": "Kerr", "QQNM_modes": None, "tail": 1}
+    with pytest.raises(ValueError):
+        utils.minimisation_compatibility_check(parameters)
+
+
+def test_minimisation_compatibility_check_accepts_valid_configuration():
+    parameters = {"template": "Kerr", "QQNM_modes": None, "tail": 0}
+    utils.minimisation_compatibility_check(parameters)
+
+
+def test_diff1_central_difference_with_padding():
+    xp = np.array([0.0, 1.0, 2.0, 3.0])
+    yp = np.array([value * value for value in xp])
+
+    derivative = utils.diff1(xp, yp)
+
+    np.testing.assert_allclose(derivative, np.array([2.0, 2.0, 4.0, 4.0]))
+
+
+def test_read_psi4_rit_format(tmp_path):
+    tar_path = tmp_path / "psi4.tar.gz"
+    asc_name = "ExtrapPsi4_l2_m2.asc"
+
+    header = "col:Time col:Real col:Imag"
+    rows = [
+        "0.0 1.0 0.5",
+        "1.0 2.0 1.5",
+    ]
+    content = "\n".join([
+        "# comment",
+        "# comment",
+        "# comment",
+        header,
+        *rows,
+    ])
+
+    with tarfile.open(tar_path, "w:gz") as tar:
+        data = content.encode("utf-8")
+        info = tarfile.TarInfo(name=f"some/path/{asc_name}")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    result = utils.read_psi4_RIT_format(str(tar_path), asc_name)
+
+    assert set(result.keys()) == {"Time", "Real", "Imag"}
+    np.testing.assert_allclose(result["Time"], np.array([0.0, 1.0]))
+    np.testing.assert_allclose(result["Real"], np.array([1.0, 2.0]))
+    np.testing.assert_allclose(result["Imag"], np.array([0.5, 1.5]))

--- a/tests/test_waveform_utils.py
+++ b/tests/test_waveform_utils.py
@@ -1,0 +1,69 @@
+import cmath
+
+import numpy as np
+
+from bayRing import waveform_utils
+
+
+def _array(values):
+    return np.array(values)
+
+
+def test_amp_phase_from_re_im_returns_expected_amplitude_and_phase():
+    h_re = _array([3.0, 0.0])
+    h_im = _array([4.0, 5.0])
+
+    amp, phase = waveform_utils.amp_phase_from_re_im(h_re, h_im)
+
+    assert list(amp) == [5.0, 5.0]
+    expected_phase = [cmath.phase(3.0 - 4.0j), cmath.phase(-5.0j)]
+    for actual, expected in zip(phase, expected_phase):
+        assert abs(actual - expected) < 1e-6
+
+
+def test_mismatch_waveforms_zero_for_identical_inputs():
+    time = _array([0.0, 0.5, 1.0, 1.5])
+
+    def amp_func(sample_times):
+        return _array([1.0 for _ in sample_times])
+
+    def phase_func(sample_times):
+        return _array([0.1 * value for value in sample_times])
+
+    delta = np.array([0.0, 0.0])
+    mismatch = waveform_utils.mismatch_waveforms(
+        delta,
+        time,
+        amp_func,
+        amp_func,
+        phase_func,
+        phase_func,
+        0.0,
+        1.5,
+    )
+
+    assert abs(mismatch) < 1e-12
+
+
+def test_find_peak_time_uses_last_peak_for_eccentric_waveforms(monkeypatch):
+    time = _array([0.0, 1.0, 2.0, 3.0])
+    amplitude = _array([0.1, 0.5, 0.4, 0.9])
+
+    monkeypatch.setattr(
+        waveform_utils,
+        "find_peaks",
+        lambda data, height=None: ([1, 3], {"peak_heights": [0.5, 0.9]}),
+    )
+
+    peak_time = waveform_utils.find_peak_time(time, amplitude, ecc=0.2)
+
+    assert peak_time == 3.0
+
+
+def test_find_peak_time_defaults_to_maximum_for_low_eccentricity():
+    time = _array([0.0, 1.0, 2.0])
+    amplitude = _array([0.1, 0.7, 0.5])
+
+    peak_time = waveform_utils.find_peak_time(time, amplitude, ecc=1e-4)
+
+    assert peak_time == 1.0


### PR DESCRIPTION
## Summary
- add a lightweight numpy stub in the test suite so bayRing modules import without the real dependency
- add structural AST-based tests that walk every bayRing module and confirm function definitions exist
- keep the utility behaviour tests working with the stubbed arrays

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690a1cbea680832e8a587b25ecbfd237